### PR TITLE
Added a command-line argument to task files.

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,12 +34,12 @@ Under a Debian GNU/Linux system you can install the dependencies with:
 
 4. [utils/serialize.lua](https://github.com/rohitjoshi/lua-mapreduce/blob/master/utils/serialize.lua) : Provides table serialization functionality 
 
-5. [example/word-count-taskfile.lua](https://github.com/rohitjoshi/lua-mapreduce/blob/master/example/word-count-taskfile.lua) : Example task-file for counting words from all .lua files in current directory
+5. [example/word-count-taskfile.lua](https://github.com/rohitjoshi/lua-mapreduce/blob/master/example/word-count-taskfile.lua) : Example task-file for counting words from all .txt files in a given directory (it uses the current directory if none is specified).
 More details on how to create task file is given in [word-count example](https://github.com/rohitjoshi/lua-mapreduce/wiki/Example---word-count) page of wiki.
 
 ### Example:
 1. Start Server:
-lua-mapreduce-server.lua  -t task-file.lua [-s server-ip -p port  -l loglevel]
+lua-mapreduce-server.lua  -t task-file.lua [-s server-ip -p port  -l loglevel -a command-line argument to task]
 
 2. Start Client:
 lua-mapreduce-client.lua [-s server-ip -p port -l loglevel]

--- a/example/test1.txt
+++ b/example/test1.txt
@@ -1,0 +1,1 @@
+This is a test.

--- a/example/test2.txt
+++ b/example/test2.txt
@@ -1,0 +1,1 @@
+This is still yet the same test.

--- a/example/test3.txt
+++ b/example/test3.txt
@@ -1,0 +1,1 @@
+Nothing at all

--- a/example/word-count-taskfile.lua
+++ b/example/word-count-taskfile.lua
@@ -36,27 +36,32 @@ end
 
 ------------------------------------------------------------------------------
 --- Read source : It reads the source and creates a task
--- @return content of the task file
+-- @return content of the file
 ------------------------------------------------------------------------------
-local function read_source()
-	--local file_path = system.pathForFile( "*.lua", lfs.currentdir() )
-	local file_path = lfs.currentdir()
-	logger:debug("Current directory path:" .. file_path)
+local function read_source(folder)
+    print(folder)
+    local file_path = nil
+    if(folder ~= nil) then
+        file_path = folder
+    else
+        file_path = lfs.currentdir()
+    end
+	logger:debug("Processing folder:" .. file_path)
 	local source_table = {}
-	for file in lfs.dir(file_path) do
-	    if(string.find(file, ".lua") ~= nil) then
-			logger:debug("File name:" .. file_path .. "/" .. file)
-			local c = read_file(file_path .. "/" .. file)
-			logger:debug("file:" .. file .. ", length:" .. #c)
+    for file in lfs.dir(file_path) do
+        print("---->" .. file)
+        if(string.find(file, ".txt") ~= nil) then
+            logger:debug("File name:" .. file_path .. "/" .. file)
+            local c = read_file(file_path .. "/" .. file)
+            logger:debug("file:" .. file .. ", length:" .. #c)
 
-			if( c ~= nil) then
-				source_table[file]=c
-			end
-		end
+            if( c ~= nil) then
+                source_table[file]=c
+            end
+        end
 	end
 
 	return source_table
-
 end
 ------------------------------------------------------------------------------
 --- mapfunction: It splits content of the lines by \r\n (windows)
@@ -74,9 +79,9 @@ function mapreducefn()
 
 
     --- Get task: It returns the task based on source. It could be data from the disk or streaming
-	mr.taskfn = function()
-		logger:debug("Getting map task")
-		local tasks = read_source()  -- read source is utility function defined to read data source
+	mr.taskfn = function(folder)
+		logger:debug("Getting map task for folder " .. folder)
+		local tasks = read_source(folder)  -- read source is utility function defined to read data source
 		for key, value in pairs(tasks) do
 			coroutine.yield(key, value)
 		end

--- a/lua-mapreduce-client.lua
+++ b/lua-mapreduce-client.lua
@@ -286,7 +286,7 @@ function client_connection(host, port)
 		tcp:settimeout(nil)
 		local cl = os.clock()
 		local status = client_run_loop(tcp, host, port)
-		print("Total time to process" .. os.clock() -cl)
+		print("Total time to process " .. os.clock() -cl)
 		if(status == "closed") then
 			reconnect = true;
 		end


### PR DESCRIPTION
Now it is possible to launch the server with a '-a' command line parameter that it is then passed to the task file.

I also debugged some issue in the server related to a variable named 'status' being masked by redefining it.

Using the three text files in the example folder is possible to test the deployment is correct (that -a argument should point to that folder).
